### PR TITLE
chore: updated doc links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # <img src="logo.svg" alt="Angle Core Module" height="40px"> Angle Core Module
 
-[![Docs](https://img.shields.io/badge/docs-%F0%9F%93%84-blue)](https://docs.angle.money/angle-core-module/overview)
-[![Developers](https://img.shields.io/badge/developers-%F0%9F%93%84-pink)](https://developers.angle.money/core-module-contracts/protocol-and-architecture-overview)
+[![Docs](https://img.shields.io/badge/docs-%F0%9F%93%84-blue)](https://docs.angle.money/overview/readme)
+[![Developers](https://img.shields.io/badge/developers-%F0%9F%93%84-pink)](https://developers.angle.money/)
 
 ## Documentation
 


### PR DESCRIPTION
Current links lead to that :
<img width="638" alt="Capture d’écran 2024-02-17 à 11 27 45" src="https://github.com/AngleProtocol/angle-core/assets/153402253/0d48e67d-707c-40ed-82f3-be88f8f0ff07">
